### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR
Created a basic Express server with a mock activity feed endpoint.

### What changed?
- Implemented a new Express server on port 3000
- Added a `/feed` endpoint that returns mock activity data
- Created sample activity feed data with three entries including user actions like photo uploads, comments, and status updates

### How to test?
1. Start the server using `node server.js`
2. Send a GET request to `http://localhost:3000/feed`
3. Verify that the response contains the mock activity feed data in JSON format

### Why make this change?
This provides a foundation for developing and testing the activity feed feature, allowing frontend development to proceed with realistic data without requiring a full backend implementation.